### PR TITLE
feat: add GitHub PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,19 @@
+### 🔗 Linked issue
+
+<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
+
+### 📚 Description
+
+<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
+
+<!----------------------------------------------------------------------
+Before creating the pull request, please make sure you do the following:
+
+- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
+- Read the contribution docs at https://nuxt.com/docs/community/contribution
+- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
+- Update the corresponding documentation if needed.
+- Include relevant tests that fail without this PR but pass with it.
+
+Thank you for contributing to Nuxt!
+----------------------------------------------------------------------->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,6 +2,17 @@
 
 <!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
 
+### ❓ Type of change
+
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
+
+- [ ] 📖 Documentation (updates to the documentation or readme)
+- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
+- [ ] 👌 Enhancement (improving an existing functionality)
+- [ ] ✨ New feature (a non-breaking change that adds functionality)
+- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
+- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
+
 ### 📚 Description
 
 <!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

The number of repositories managed by Nuxt organizations is increasing day by day, and I think the cost of managing the repositories is on the rise.
I often see PRs that add GitHub PR templates to each repository for repository operation, but I think this can be solved by placing them in `nuxt/.github`.

- https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

#### The behavior that occurs in each repository is as follows.

##### `.github/pull_request_template.md` has been placed

The pull_request_template.md set in each repository will take priority.

>  If a repository has any files in its own .github/ISSUE_TEMPLATE folder, including issue templates or a config.yml file, none of the contents of the default .github/ISSUE_TEMPLATE folder will be used.

##### `.github/pull_request_template.md` has not been placed

The pull_request_template.md in this repository will be used when creating a PR.

### ✍️ Note

- Only the GitHub PR template is added in this PR. The GitHub Issue template will be added in a separate PR.
- If there are no issues with this PR, we will take the same steps in the Nuxt modules organization.

