### PR TITLE
feat: add GitHub Issue template

### DIFF
--- a/ISSUE_TEMPLATE/bug-report.yml
+++ b/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,49 @@
+name: '🐞 Bug report'
+description: Create a report to help us improve Nuxt
+labels: ['pending triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please carefully read the contribution docs before creating a bug report
+        👉 https://nuxt.com/docs/community/reporting-bugs
+
+        Please use a template below to create a minimal reproduction
+        👉 https://stackblitz.com/github/nuxt/starter/tree/v3
+        👉 https://codesandbox.io/s/github/nuxt/starter/tree/v3
+  - type: textarea
+    id: bug-env
+    attributes:
+      label: Environment
+      description: You can use `npx nuxi info` to fill this section
+      placeholder: Environment
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a repo that can reproduce the problem you ran into. A [**minimal reproduction**](https://nuxt.com/docs/community/reporting-bugs#create-a-minimal-reproduction) is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided we might close it.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: additonal
+    attributes:
+      label: Additional context
+      description: If applicable, add any other context about the problem here
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Optional if provided reproduction. Please try not to insert an image but copy paste the log text.
+      render: shell-script

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📚 Nuxt Documentation
+    url: https://nuxt.com/docs
+    about: Check the documentation for usage of Nuxt
+  - name: 💬 Discussions
+    url: https://github.com/nuxt/nuxt/discussions
+    about: Use discussions if you have another issue, an idea for improvement or for asking questions.

--- a/ISSUE_TEMPLATE/feature-request.yml
+++ b/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+name: '🚀 Feature request'
+description: Suggest a feature that will improve Nuxt
+labels: ['pending triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this feature request!
+
+        Please carefully read the contribution docs before suggesting a new feature
+        👉 https://nuxt.com/docs/community/contribution/#creating-an-issue
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of what you think would be a helpful addition to Nuxt, including the possible use cases and alternatives you have considered. If you have a working prototype or module that implements it, please include a link.
+      placeholder: Feature description
+    validations:
+      required: true
+  - type: checkboxes
+    id: additional-info
+    attributes:
+      label: Additional information
+      description: Additional information that helps us decide how to proceed.
+      options:
+        - label: Would you be willing to help implement this feature?
+        - label: Could this feature be implemented as a module?
+  - type: checkboxes
+    id: required-info
+    attributes:
+      label: Final checks
+      description: Before submitting, please make sure you do the following
+      options:
+        - label: Read the [contribution guide](https://nuxt.com/docs/community/contribution).
+          required: true
+        - label: Check existing [discussions](https://github.com/nuxt/nuxt/discussions) and [issues](https://github.com/nuxt/nuxt/issues).
+          required: true


### PR DESCRIPTION
### 🔗 Linked issue

related #4 .

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

GitHub Issue template has been added.

It would be a pain to prepare a generic version for all repositories, so I've copied the contents of the Nuxt repo as is.

- https://github.com/nuxt/nuxt/tree/65a98cf7be746d0200baa2b33e41df4f7f3ee0f7/.github/ISSUE_TEMPLATE

I think it's fine to have each repository make changes as needed.