### PR TITLE
ci: make it a module and ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",
   "devDependencies": {


### PR DESCRIPTION
Adds `type: module` to package.json and ignores `node_modules` in `.gitignore`.