### PR TITLE
ci: fix invalid workflow syntax

### DIFF
--- a/.github/workflows/triage-comment.yml
+++ b/.github/workflows/triage-comment.yml
@@ -46,9 +46,9 @@ jobs:
           echo "## Skipped" >> $GITHUB_STEP_SUMMARY
           echo "Comment from collaborator/member/owner - no automated analysis performed." >> $GITHUB_STEP_SUMMARY
 
-      - if: steps.check-auth.outputs.is_collaborator != 'true'
-        parallel:
-          - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - parallel:
+          - if: steps.check-auth.outputs.is_collaborator != 'true'
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
             with:
               repository: nuxt/.github
               ref: ${{ inputs.scripts-ref }}
@@ -56,7 +56,8 @@ jobs:
               path: .shared
               persist-credentials: false
 
-          - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+          - if: steps.check-auth.outputs.is_collaborator != 'true'
+            uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
             with:
               node-version: lts/*
 

--- a/.github/workflows/triage-comment.yml
+++ b/.github/workflows/triage-comment.yml
@@ -47,8 +47,8 @@ jobs:
           echo "Comment from collaborator/member/owner - no automated analysis performed." >> $GITHUB_STEP_SUMMARY
 
       - parallel:
-          - if: steps.check-auth.outputs.is_collaborator != 'true'
-            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+          - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            if: steps.check-auth.outputs.is_collaborator != 'true'
             with:
               repository: nuxt/.github
               ref: ${{ inputs.scripts-ref }}
@@ -56,8 +56,8 @@ jobs:
               path: .shared
               persist-credentials: false
 
-          - if: steps.check-auth.outputs.is_collaborator != 'true'
-            uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+          - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+            if: steps.check-auth.outputs.is_collaborator != 'true'
             with:
               node-version: lts/*
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

I introduced a bug in [#42](https://github.com/nuxt/.github/pull/42/changes#diff-795b441fd4a9f689dd23d5da3f132d0848f61126b25446ae571d13e69733d52d) 🫣. The `if` keyword cannot be used in the same block as the `parallel` keyword ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel)). This bug makes the entire workflow invalid and therefore it [never runs](https://github.com/nuxt/nuxt/actions/runs/29345956312).

This fix applies the `if` condition to both of the steps, which will have the desired effect.



<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
